### PR TITLE
Use english plural if the language is not supported

### DIFF
--- a/TTTLocalizedPluralString.m
+++ b/TTTLocalizedPluralString.m
@@ -441,7 +441,7 @@ static NSString * TTTVietnamesePluralRuleForCount(NSUInteger count) {
 }
 
 NSString * TTTLocalizedPluralStringKeyForCountAndSingularNoun(NSUInteger count, NSString *singular) {
-    NSString *languageCode = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
+    NSString *languageCode = @"bb"; //[[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
     return TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(count, singular, languageCode);
 }
 
@@ -518,8 +518,8 @@ NSString * TTTLocalizedPluralStringKeyForCountAndSingularNounForLanguage(NSUInte
     } else if ([languageCode hasPrefix:@"vi"]) {
         pluralRule = TTTVietnamesePluralRuleForCount(count);
     } else {
-        NSLog(@"Unsupported language: %@", languageCode);
-        return nil;
+        NSLog(@"Unsupported language: %@. Use english instead", languageCode);
+        pluralRule = TTTEnglishPluralRuleForCount(count);
     }
     
     return [NSString stringWithFormat:@"%@_%@", singular, pluralRule];

--- a/TTTLocalizedPluralString.podspec
+++ b/TTTLocalizedPluralString.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = 'TTTLocalizedPluralString'
   s.summary      = 'NSLocalizedString with a Count Argument.'
-  s.version      = '0.0.9'
+  s.version      = '0.0.10'
   s.license      = 'MIT'
   s.homepage     = 'https://github.com/mattt/TTTLocalizedPluralString'
   s.social_media_url = 'https://twitter.com/mattt'
   s.author       = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source       = { :git => 'https://github.com/mattt/TTTLocalizedPluralString.git', :tag => '0.0.9' }
+  s.source       = { :git => 'https://github.com/mattt/TTTLocalizedPluralString.git', :tag => '0.0.10' }
   s.source_files = 'TTTLocalizedPluralString.{h,m}'
 end


### PR DESCRIPTION
Instead of returning a nil when the language is not recognized, we use "english" as the default plural. 